### PR TITLE
Set postgres autoinstall to "skip" when skipping it.

### DIFF
--- a/bin/configure
+++ b/bin/configure
@@ -9,6 +9,7 @@ input_start() {
 
 	if [ "$already_setup_with_mysql_addon" != "" ]; then
 		echo "Installation is already using MySQL, skipping postgres addon."
+		wiz_set "postgres/autoinstall" "skip"
 		STATE="done"
 		return 0;
 	fi


### PR DESCRIPTION
Otherwise, you'll be getting this error:

```
[postgres] ./bin/preinstall
ERROR: Unknown value for postgres/autoinstall
```